### PR TITLE
Return the internal argument info from arginfo.php

### DIFF
--- a/includes/arginfo.php
+++ b/includes/arginfo.php
@@ -20,7 +20,7 @@
  * '...=' indicates it is both variadic and optional.
  */
 
-$internal_arginfo = [
+return [
 'abs' => ['int|float', 'number'=>'int|float'],
 'accelerator_get_configuration' => ['array'],
 'accelerator_get_scripts' => ['array'],

--- a/phan
+++ b/phan
@@ -12,10 +12,10 @@ require __DIR__.'/includes/cli.php';
 require __DIR__.'/includes/util.php';
 require __DIR__.'/includes/pass1.php';
 require __DIR__.'/includes/pass2.php';
-require __DIR__.'/includes/arginfo.php';
 require __DIR__.'/includes/ast_util.php';
 
 // Globals where we store everything
+$internal_arginfo = require __DIR__.'/includes/arginfo.php';
 $classes = [];
 $functions = [];
 $summary = [ 'classes'=>0, 'traits'=>0, 'methods'=>0, 'functions'=>0, 'closures'=>0, 'conditionals'=>0 ];


### PR DESCRIPTION
The information from arginfo.php may be useful to other projects, so instead of declaring a global variable, it now returns the array to make it easier for reuse elsewhere.
