### PR TITLE
Fix ast extension requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,6 @@
     ],
     "require": {
         "php": ">=7.0",
-        "ext-php-ast": "*"
+        "ext-ast": "*"
     }
 }


### PR DESCRIPTION
When trying to pull phan using composer using a composer.json similar to this one:

```
{
  "minimum-stability":"dev",
  "require": {
    "rlerdorf/phan": "*"
  },
  "repositories": [
    {
      "type": "vcs",
      "url": "https://github.com/rlerdorf/phan.git"
    }
  ]
}
```

it would error

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for rlerdorf/phan * -> satisfiable by rlerdorf/phan[dev-master].
    - rlerdorf/phan dev-master requires ext-php-ast * -> the requested PHP extension php-ast is missing from your system.
```

because the extension is just called `ast` within php.

This pull request fixes this issue.
